### PR TITLE
Add two github issue triage queries to links.hbs

### DIFF
--- a/front/app/templates/links.hbs
+++ b/front/app/templates/links.hbs
@@ -8,6 +8,12 @@
     <li><a href="https://users.rust-lang.org/about" target="_blank">users.rust-lang.org stats</a></li>
     <li><a href="https://internals.rust-lang.org/about" target="_blank">internals.rust-lang.org stats</a></li>
     <li><a href="http://redditmetrics.com/r/rust" target="_blank">/r/rust stats</a></li>
+    <li><a href="https://github.com/pulls?q=is%3Aopen+is%3Apr+org%3Arust-lang+org%3Arust-lang-nursery+org%3Arust-deprecated+sort%3Aupdated-asc">
+      Least-recently updated pull requests across orgs
+    </a></li>
+    <li><a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+org%3Arust-lang+org%3Arust-lang-nursery+org%3Arust-deprecated+sort%3Aupdated-asc">
+      Least-recently updated issues across orgs
+    </a></li>
 
 </ul>
 </h5>


### PR DESCRIPTION
Not sure this is the best place for these, but these are the kinds of useful github queries that are useful to disseminate and hard to remember.