### PR TITLE
Missing vagrant environment configurations

### DIFF
--- a/vagrant/native_deps.sh
+++ b/vagrant/native_deps.sh
@@ -14,7 +14,7 @@ chown -R vagrant:vagrant /rust-dashboard/
 update-locale LANGE=en_US.UTF-8
 locale-gen en_US.UTF-8
 apt-get update
-apt-get install -y postgresql libpq-dev npm nodejs curl
+apt-get install -y postgresql libpq-dev npm nodejs curl git
 ln -s /usr/bin/nodejs /usr/bin/node
 
 # frontend deps

--- a/vagrant/pg_hba.conf
+++ b/vagrant/pg_hba.conf
@@ -1,2 +1,3 @@
 local   all             all                                     trust
 host    all             all           127.0.0.1/24                md5
+host    all             all           ::1/128                     md5


### PR DESCRIPTION
Just some minor adjustments I had to make to get the vagrant box running.

- Git is required to be on the guest to install some of the bower dependencies
- IPv6 seems to get enabled at some point after rebooting the virtual machine, postgres's pg_hba.conf doesn't have any rules for IPv6's localhost

Other than that, everything ran as expected! I got the environment up and running on a Windows 10 machine, so if you wanted to stress how well your vagrant scripts are configured I can definitely say they work quite well!

I did hit some windows specific quirks relating to CRLF vs LF and symlinks, but these are environment problems so I'm not sure if documenting the solutions to them is in scope of this project.