### PR TITLE
Vagrant Bootstrap Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ cd /vagrant && cargo run -- scrape
 To install dependencies for the front-end development server and run it:
 
 ```
-$ cd /vagrant/front && npm install && bower install
+$ cd /vagrant/front
 $ ember server --proxy=http://localhost:8080
 ```
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,11 @@ Vagrant.configure("2") do |config|
                       path: "vagrant/native_deps.sh",
                       keep_color: true)
 
+  config.vm.provision("frontend",
+                      type: "shell",
+                      path: "vagrant/frontend.sh",
+                      keep_color: true)
+
   config.vm.provision("postgres",
                       type: "shell",
                       path: "vagrant/postgres.sh",

--- a/vagrant/frontend.sh
+++ b/vagrant/frontend.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+# global deps
+npm install -g ember-cli
+npm install -g bower
+
+# keep node modules in VM file system to speedup npm install and fix it on Windows/Linux machines
+mkdir -p /home/vagrant/local_front/node_modules
+rm -f /vagrant/front/node_modules || true
+ln -s /home/vagrant/local_front/node_modules /vagrant/front/
+chown -R vagrant:vagrant /home/vagrant/local_front
+chown -R vagrant:vagrant /vagrant/front/node_modules
+
+# install local deps
+su vagrant <<'EOF'
+cd /vagrant/front
+npm install
+bower install
+EOF

--- a/vagrant/native_deps.sh
+++ b/vagrant/native_deps.sh
@@ -16,7 +16,3 @@ locale-gen en_US.UTF-8
 apt-get update
 apt-get install -y postgresql libpq-dev npm nodejs curl git
 ln -s /usr/bin/nodejs /usr/bin/node
-
-# frontend deps
-npm install -g ember-cli
-npm install -g bower

--- a/vagrant/vagrant_env.sh
+++ b/vagrant/vagrant_env.sh
@@ -8,6 +8,7 @@ export GITHUB_SCRAPE_INTERVAL=2
 export RELEASES_SCRAPE_INTERVAL=720
 export BUILDBOT_SCRAPE_INTERVAL=80
 export SERVER_PORT=8080
+export POST_COMMENTS=false
 
 # VM config for cargo
 export CARGO_TARGET_DIR=/rust-dashboard/target


### PR DESCRIPTION
Some small tweaks to improve first time vagrant up experience

**Added POST_COMMENTS to vagrant_env.sh** 
Fixes freshly bootstraped vagrant boxes from failing to run the rust back end. The recent changes require POST_COMMENTS to be true or false before running the rust back end, but this is not included in vagrant_env.sh. I assume false is a sane default in this case.

**Created frontend provisioning script**
This script handles pulling in all of the frontend's dependencies. It also creates a symlink from the node_modules directory inside the shared /vagrant folder to the Vagrant VM's home folder. This fixes issues in windows where npm install tries to create symlinks in a NTFS backed file system. It also speeds up the npm install process as Virtual Box's shared folder engine is significantly slower than a native file system, especially with npm's large number of small files.

**Open Discussion**
I'm not sure if having the npm and bower install happen at provision time is the best plan or not. While convenient from my perspective, I can see it being annoying if, for example, someone just wants to hack on the scraper. So I'm not bound to keeping that part in this PR, but the symlink is a definite improvement IMO, it really speeds up the install and helps to work around OS/VM Engine specific quirks.

