### PR TITLE
Bootstrap all repos from Github

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 use std::env;
 
 pub const RFC_BOT_MENTION: &'static str = "@rfcbot";
+pub const GH_ORGS: [&'static str; 3] = ["rust-lang", "rust-lang-nursery", "rust-lang-deprecated"];
 
 lazy_static! {
     pub static ref CONFIG: Config = {

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -264,15 +264,13 @@ impl Client {
         self.set_headers(self.client.post(url).body(payload)).send()
     }
 
-    fn get<'a>(&self,
-               url: &'a str,
-               params: Option<&ParameterMap>)
-               -> Result<Response, hyper::error::Error> {
+    fn get(&self, url: &str, params: Option<&ParameterMap>)
+           -> Result<Response, hyper::error::Error> {
 
         let qp_string = match params {
             Some(p) => {
                 let mut qp = String::from("?");
-                for (k, v) in p.iter() {
+                for (k, v) in p {
                     if qp.len() > 1 {
                         qp.push('&');
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,9 +96,8 @@ fn main() {
         match source {
             "github" => {
                 info!("Bootstrapping GitHub data since {}", start);
-                info!("{:#?}",
-                      github::ingest_since("rust-lang/rust", start)
-                          .map(|()| "Ingestion succesful."))
+                scraper::scrape_github(start);
+                info!("Ingestion complete");
             }
 
             "releases" => {


### PR DESCRIPTION
Previously, bootstrap would only get information for `rust-lang/rust` instead of all repos in `rust-lang`, `rust-lang-nursery` or `rust-lang-deprecated`. This PR refactors the scraping logic into its own function and re-uses that function during bootstrap.