### PR TITLE
Remove duplicate issues

### DIFF
--- a/migrations/20170323184941_unique_issue_repo_number/down.sql
+++ b/migrations/20170323184941_unique_issue_repo_number/down.sql
@@ -1,1 +1,2 @@
 DROP INDEX issue_repo_number;
+DROP INDEX pullrequest_repo_number;

--- a/migrations/20170323184941_unique_issue_repo_number/down.sql
+++ b/migrations/20170323184941_unique_issue_repo_number/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX issue_repo_number;

--- a/migrations/20170323184941_unique_issue_repo_number/up.sql
+++ b/migrations/20170323184941_unique_issue_repo_number/up.sql
@@ -1,2 +1,2 @@
-CREATE UNIQUE INDEX issue_repo_number
-ON issue(repository, number);
+CREATE UNIQUE INDEX issue_repo_number ON issue(repository, number);
+CREATE UNIQUE INDEX pullrequest_repo_number ON pullrequest(repository, number);

--- a/migrations/20170323184941_unique_issue_repo_number/up.sql
+++ b/migrations/20170323184941_unique_issue_repo_number/up.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX issue_repo_number
+ON issue(repository, number);

--- a/migrations/20170323184941_unique_issue_repo_number/up.sql
+++ b/migrations/20170323184941_unique_issue_repo_number/up.sql
@@ -1,2 +1,2 @@
-CREATE UNIQUE INDEX issue_repo_number ON issue(repository, number);
-CREATE UNIQUE INDEX pullrequest_repo_number ON pullrequest(repository, number);
+CREATE UNIQUE INDEX issue_repo_number ON issue(repository, "number");
+CREATE UNIQUE INDEX pullrequest_repo_number ON pullrequest(repository, "number");

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -2,14 +2,19 @@ use diesel;
 use diesel::prelude::*;
 use diesel::types::{Integer, VarChar};
 
-use github::update_issue;
+use github::{update_issue, update_pr};
 
 use DB_POOL;
 
 pub fn fix() {
     for (repo, number) in get_duplicate_issues() {
-        delete_duplicates(&repo, number);
+        delete_duplicate_issues(&repo, number);
         update_issue(&repo, number).expect("Failed to update issue");
+    }
+
+    for (repo, number) in get_duplicate_prs() {
+        delete_duplicate_prs(&repo, number);
+        update_pr(&repo, number).expect("Failed to update issue");
     }
 }
 
@@ -24,7 +29,7 @@ fn get_duplicate_issues() -> Vec<(String, i32)> {
         .expect("Failed to load duplicates")
 }
 
-fn delete_duplicates(repo: &str, issue: i32) {
+fn delete_duplicate_issues(repo: &str, issue: i32) {
     use domain::schema::issue;
     use domain::schema::issuecomment;
 
@@ -45,4 +50,28 @@ fn delete_duplicates(repo: &str, issue: i32) {
                    .filter(issue::repository.eq(repo)))
         .execute(&*conn)
         .expect("Failed to delete issue");
+}
+
+fn get_duplicate_prs() -> Vec<(String, i32)> {
+    use diesel::expression::dsl::*;
+
+    let conn = DB_POOL.get().expect("Failed to acquire connection");
+    diesel::select(sql::<(VarChar, Integer)>("repository, number \
+        FROM pullrequest \
+        GROUP BY number, repository HAVING COUNT(*) > 1"))
+        .load::<(String, i32)>(&*conn)
+        .expect("Failed to load duplicates")
+}
+
+fn delete_duplicate_prs(repo: &str, issue: i32) {
+    use domain::schema::pullrequest;
+
+    let conn = DB_POOL.get().expect("Failed to acquire connection");
+
+    // Then delete actual issues
+    diesel::delete(pullrequest::table
+                   .filter(pullrequest::number.eq(issue))
+                   .filter(pullrequest::repository.eq(repo)))
+        .execute(&*conn)
+        .expect("Failed to delete pr");
 }

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -1,0 +1,48 @@
+use diesel;
+use diesel::prelude::*;
+use diesel::types::{Integer, VarChar};
+
+use github::update_issue;
+
+use DB_POOL;
+
+pub fn fix() {
+    for (repo, number) in get_duplicate_issues() {
+        delete_duplicates(&repo, number);
+        update_issue(&repo, number).expect("Failed to update issue");
+    }
+}
+
+fn get_duplicate_issues() -> Vec<(String, i32)> {
+    use diesel::expression::dsl::*;
+
+    let conn = DB_POOL.get().expect("Failed to acquire connection");
+    diesel::select(sql::<(VarChar, Integer)>("repository, number \
+        FROM issue \
+        GROUP BY number, repository HAVING COUNT(*) > 1"))
+        .load::<(String, i32)>(&*conn)
+        .expect("Failed to load duplicates")
+}
+
+fn delete_duplicates(repo: &str, issue: i32) {
+    use domain::schema::issue;
+    use domain::schema::issuecomment;
+
+    let conn = DB_POOL.get().expect("Failed to acquire connection");
+
+    // Delete comments first to avoid foreign key problems
+    let ids = issue::table.select(issue::id)
+        .filter(issue::number.eq(issue))
+        .filter(issue::repository.eq(repo));
+    diesel::delete(issuecomment::table
+                   .filter(issuecomment::fk_issue.eq_any(ids)))
+        .execute(&*conn)
+        .expect("Failed to delete issue comments");
+
+    // Then delete actual issues
+    diesel::delete(issue::table
+                   .filter(issue::number.eq(issue))
+                   .filter(issue::repository.eq(repo)))
+        .execute(&*conn)
+        .expect("Failed to delete issue");
+}

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -178,6 +178,15 @@ impl Client {
         self.get_models(&url, &params)
     }
 
+    pub fn fetch_pr(&self, repo: &str, number: i32) -> DashResult<PullRequestFromJson> {
+        let url = format!("{}/repos/{}/pulls/{}", BASE_URL, repo, number);
+        let mut buf = String::new();
+
+        self.get(&url, None)?
+            .read_to_string(&mut buf)?;
+        Ok(serde_json::from_str(&buf)?)
+    }
+
     pub fn fetch_pull_request(&self, pr_info: &PullRequestUrls) -> DashResult<PullRequestFromJson> {
         let url = pr_info.get("url");
 

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -161,6 +161,23 @@ impl Client {
         Ok(models)
     }
 
+    pub fn fetch_issue(&self, repo: &str, number: i32) -> DashResult<IssueFromJson> {
+        let url = format!("{}/repos/{}/issues/{}", BASE_URL, repo, number);
+        let mut buf = String::new();
+
+        self.get(&url, None)?
+            .read_to_string(&mut buf)?;
+
+        Ok(serde_json::from_str(&buf)?)
+    }
+
+    pub fn fetch_comments(&self, repo: &str, number: i32) -> DashResult<Vec<CommentFromJson>> {
+        let url = format!("{}/repos/{}/issues/{}/comments", BASE_URL, repo, number);
+        let params = ParameterMap::new();
+
+        self.get_models(&url, &params)
+    }
+
     pub fn fetch_pull_request(&self, pr_info: &PullRequestUrls) -> DashResult<PullRequestFromJson> {
         let url = pr_info.get("url");
 

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -127,6 +127,18 @@ pub fn ingest_since(repo: &str, start: DateTime<UTC>) -> DashResult<()> {
     Ok(())
 }
 
+pub fn update_issue(repo: &str, number: i32) -> DashResult<()> {
+    let issue = GH.fetch_issue(repo, number)?;
+    let comments = GH.fetch_comments(repo, number)?;
+
+    handle_issue(issue, repo)?;
+    for comment in comments {
+        handle_comment(comment, repo)?;
+    }
+
+    Ok(())
+}
+
 pub fn handle_pr(pr: PullRequestFromJson, repo: &str) -> DashResult<()> {
     use domain::schema::pullrequest::dsl::*;
 

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -139,6 +139,11 @@ pub fn update_issue(repo: &str, number: i32) -> DashResult<()> {
     Ok(())
 }
 
+pub fn update_pr(repo: &str, number: i32) -> DashResult<()> {
+    let pr = GH.fetch_pr(repo, number)?;
+    handle_pr(pr, repo)
+}
+
 pub fn handle_pr(pr: PullRequestFromJson, repo: &str) -> DashResult<()> {
     use domain::schema::pullrequest::dsl::*;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ mod buildbot;
 mod config;
 mod domain;
 mod error;
+mod fix;
 mod github;
 mod releases;
 mod reports;
@@ -76,15 +77,13 @@ fn main() {
 
 
     if let Some(_) = args.subcommand_matches("scrape") {
-
         // this will block on joining never-ending threads
         // need to come up with a better way to do this...
         scraper::start_scraping();
-
     } else if let Some(_) = args.subcommand_matches("serve") {
-
         server::serve();
-
+    } else if let Some(_) = args.subcommand_matches("fix") {
+        fix::fix();
     } else if let Some(args) = args.subcommand_matches("bootstrap") {
         // OK to unwrap, this has already been validated by clap
         let start = make_date_time(args.value_of("since").unwrap())
@@ -125,7 +124,7 @@ fn make_date_time(date_str: &str) -> Result<DateTime<UTC>, chrono::ParseError> {
 fn init_cli<'a>() -> ArgMatches<'a> {
     let scrape = SubCommand::with_name("scrape").about("scrapes any updated data");
     let serve = SubCommand::with_name("serve").about("serve the dashboard JSON API");
-
+    let fix = SubCommand::with_name("fix").about("fix corrupted data");
     let bootstrap = SubCommand::with_name("bootstrap")
         .about("bootstraps the database")
         .arg(Arg::with_name("source")
@@ -152,6 +151,7 @@ fn init_cli<'a>() -> ArgMatches<'a> {
         .author(env!("CARGO_PKG_AUTHORS"))
         .about(env!("CARGO_PKG_DESCRIPTION"))
         .subcommand(bootstrap)
+        .subcommand(fix)
         .subcommand(scrape)
         .subcommand(serve)
         .get_matches()


### PR DESCRIPTION
I added a new subcommand `fix`, that will search for all duplicate issues, delete them and their associated comments, and then rescrapes their data from Github. It's not super resistant to errors, but hopefully this is a one time thing 🙏.

I've also added a migration to create a unique index on `issue` so that this doesn't happen again.

The expected usage would be:
```
cargo run --release -- fix
diesel migration run
```

(Have confirmed it addresses the overcounting noted in https://github.com/dikaiosune/rust-dashboard/issues/114#issuecomment-283452665).