### PR TITLE
Process build info for all commits from @bors

### DIFF
--- a/src/github/webhooks.rs
+++ b/src/github/webhooks.rs
@@ -176,14 +176,14 @@ fn authenticated_handler(event: Event) -> DashResult<()> {
 }
 
 #[derive(Debug)]
-pub struct Event {
+struct Event {
     delivery_id: String,
     event_name: String,
     payload: Payload,
 }
 
 #[derive(Debug)]
-pub enum Payload {
+enum Payload {
     Issues(IssuesEvent),
     IssueComment(IssueCommentEvent),
     PullRequest(PullRequestEvent),
@@ -193,14 +193,14 @@ pub enum Payload {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct IssuesEvent {
+struct IssuesEvent {
     action: String,
     issue: IssueFromJson,
     repository: Repository,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct IssueCommentEvent {
+struct IssueCommentEvent {
     action: String,
     issue: IssueFromJson,
     repository: Repository,
@@ -208,7 +208,7 @@ pub struct IssueCommentEvent {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct PullRequestEvent {
+struct PullRequestEvent {
     action: String,
     repository: Repository,
     number: i32,
@@ -216,23 +216,23 @@ pub struct PullRequestEvent {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct Repository {
+struct Repository {
     full_name: String,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct StatusEvent {
+struct StatusEvent {
     commit: Commit,
     state: String,
     target_url: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct Commit {
+struct Commit {
     committer: Committer,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct Committer {
+struct Committer {
     login: String,
 }

--- a/src/github/webhooks.rs
+++ b/src/github/webhooks.rs
@@ -161,10 +161,7 @@ fn authenticated_handler(event: Event) -> DashResult<()> {
 
         Payload::Status(status_event) => {
             if status_event.state != "pending" &&
-                status_event.branches.iter().any(|branch| {
-                    branch.name == "auto" &&
-                    branch.commit.sha == status_event.sha
-                })
+                status_event.commit.committer.login == "bors"
             {
                 if let Some(url) = status_event.target_url {
                     builds::ingest_status_event(url)?
@@ -219,25 +216,23 @@ pub struct PullRequestEvent {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct StatusEvent {
-    sha: String,
-    state: String,
-    target_url: Option<String>,
-    branches: Vec<Branch>,
-}
-
-#[derive(Debug, Deserialize)]
 pub struct Repository {
     full_name: String,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct Branch {
-    name: String,
+pub struct StatusEvent {
     commit: Commit,
+    state: String,
+    target_url: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct Commit {
-    sha: String
+    committer: Committer,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Committer {
+    login: String,
 }


### PR DESCRIPTION
Right now, https://rusty-dash.com/builds is empty, so something's clearly not working correctly.

The old logic was:
1. Get a status update from Github
2. If status says the build is finished and the commit is the `HEAD` of the `auto` branch, then process.

Without looking at the logs, I'm guessing that the problem is that:
1. @bors pushes a new commit to the `auto` branch
2. A build starts. We get a notification but ignore it (because the status is still `pending`)
3. The build finishes and @bors pushes overwrites onto the `auto` branch
4. We receive a status update that the build has finished, but because the commit has been overwritten on `auto`, we ignore it.

This assumes that somehow @bors overwrites the `auto` branch before the webhook notification gets sent out, so I'm not sure how plausible this actually is, but `¯\_(ツ)_/¯`.

Hopefully, by filtering based on the committer instead of the branch name, we can get around this problem.